### PR TITLE
Check images too

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ local
 *.swp
 .tidyall.d/
 /WWW-RoboCop*
+MYMETA.*
+Makefile
+pm_to_blib

--- a/lib/WWW/RoboCop.pm
+++ b/lib/WWW/RoboCop.pm
@@ -36,15 +36,11 @@ has report_for_url => (
                 $response->redirects
                 ? (
                     redirects => [
-                        map {
-                            {
-                                status => $_->code,
-                                uri    => $_->request->uri,
-                            }
-                        } $response->redirects
+                        map { { status => $_->code, uri => $_->request->uri, } }
+                          $response->redirects
                     ],
                     target_url => $response->request->uri,
-                    )
+                  )
                 : (),
                 referrer => $referring_url,
                 status   => $response->code,
@@ -83,13 +79,12 @@ sub _get {
     $self->_add_url_to_history( $fetched_url, $report );
 
     my @links =
-        map { my $u = URI->new( $_->url_abs ); $u->fragment(undef); [ $_, $u ] }
-        grep { $_->url !~ /\A#/ } # no named anchors
-        map { @{ $self->ua->$_() } }
-        qw( links images );
+      map { my $u = URI->new( $_->url_abs ); $u->fragment(undef); [ $_, $u ] }
+      grep { $_->url !~ /\A#/ }                           # no named anchors
+      map { @{ $self->ua->$_() } } qw( links images );
 
     foreach my $tuple (@links) {
-        my( $mech_link, $uri ) = @$tuple;
+        my ( $mech_link, $uri ) = @$tuple;
         next unless $self->_should_follow_link( $mech_link, $fetched_url );
         next if $self->_has_processed_url($uri);
         next unless $uri->can('host');    # no mailto: links


### PR DESCRIPTION
Over in perladvent/Perl-Advent#305 and perladvent/Perl-Advent#306, they were wondering about some missing images not showing up in check-site.pl. Turns out the Robocop was not looking at them at all.

I'm not sure that this is the way we should do it. This will pull more things than current users are used to seeing. Maybe it should be enabled or disabled with a switch. If you don't like how I did it, feel free to take what's useful and forget the rest.